### PR TITLE
Fix collections checksum hook

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,3 +22,8 @@ jobs:
       uses: actions/checkout@v2
     - name: Build
       run: sudo -E env "PATH=$PATH" make install
+    - name: Tests
+      run: |
+        sudo rm $(which yq)  # need to clean the old yq available in the workers
+        sudo -E env "PATH=$PATH" make install_luet  # some extensions use luet (i.e. autobump-github) for testing
+        make test

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 BUNDLED_EXTENSIONS ?= k8s-build-scheduler migrate-emerge remote-exec geninitramfs kernel-switcher autobump-github geniso genimage qa-artefacts migrate-entropy package-browser parallel-tools portage apkbuildconverter repo-devkit
+BUNDLED_EXTENSIONS_TEST ?= autobump-github
 UBINDIR ?= /usr/bin
 DESTDIR ?=
 
@@ -9,3 +10,9 @@ build:
 
 install: build
 	for d in $(BUNDLED_EXTENSIONS); do $(MAKE) -C extensions/$$d install; done
+
+install_luet:
+	curl https://get.mocaccino.org/luet/get_luet_root.sh | sh
+
+test:
+	for d in $(BUNDLED_EXTENSIONS_TEST); do $(MAKE) -C extensions/$$d test; done

--- a/extensions/autobump-github/Makefile
+++ b/extensions/autobump-github/Makefile
@@ -9,3 +9,7 @@ build:
 install: build
 	install -d $(DESTDIR)/$(UBINDIR)
 	install -m 0755 luet-autobump-github $(DESTDIR)/$(UBINDIR)/
+
+test:
+	TREE_DIR=test_packages FAIL_ON_ERROR=true ./luet-autobump-github
+	git checkout test_packages

--- a/extensions/autobump-github/luet-autobump-github
+++ b/extensions/autobump-github/luet-autobump-github
@@ -1,9 +1,15 @@
 #!/bin/bash
-#set -ex
+#set -e
 # Auto bumper script by Ettore Di Giacinto <mudler@sabayonlinux.org>
 # License: MIT
 # Requires yq and jq
 # It bumps to latest tag annotated in the specs
+
+FAIL_ON_ERROR="${FAIL_ON_ERROR:-false}"
+
+if [[ $FAIL_ON_ERROR == "true" ]]; then
+  set -e
+fi
 
 # Options
 AUTO_GIT="${AUTO_GIT:-false}"

--- a/extensions/autobump-github/test_packages/collection_package/collection.yaml
+++ b/extensions/autobump-github/test_packages/collection_package/collection.yaml
@@ -1,0 +1,35 @@
+packages:
+  - name: "golang1"
+    category: "build"
+    version: 1.16.6+7
+    base_url: https://golang.org/dl
+    hidden: true # No need to make it installable for now
+    labels:
+      autobump.revdeps: "false"
+      autobump.string_replace: '{ "prefix": "" }'
+      autobump.strategy: "custom"
+      autobump.prefix: "prefix"
+      autobump.hook: |
+        curl -s -L 'https://golang.org/VERSION?m=text' | sed 's/go//g'
+      autobump.version_hook: |
+        curl -s -L 'https://golang.org/VERSION?m=text' | sed 's/go//g'
+      package.version: "1.16.6"
+      autobump.checksum_hook: "curl -q -L https://storage.googleapis.com/golang/go{{.Values.labels.package.version}}.linux-amd64.tar.gz.sha256"
+      package.checksum: "be333ef18b3016e9d7cb7b1ff1fdb0cac800ca0be4cf2290fe613b3d069dfe0d"
+  - name: "golang2"
+    category: "build"
+    version: 1.16.6+7
+    base_url: https://golang.org/dl
+    hidden: true # No need to make it installable for now
+    labels:
+      autobump.revdeps: "false"
+      autobump.string_replace: '{ "prefix": "" }'
+      autobump.strategy: "custom"
+      autobump.prefix: "prefix"
+      autobump.hook: |
+        curl -s -L 'https://golang.org/VERSION?m=text' | sed 's/go//g'
+      autobump.version_hook: |
+        curl -s -L 'https://golang.org/VERSION?m=text' | sed 's/go//g'
+      package.version: "1.16.6"
+      autobump.checksum_hook: "curl -q -L https://storage.googleapis.com/golang/go{{.Values.labels.package.version}}.linux-amd64.tar.gz.sha256"
+      package.checksum: "be333ef18b3016e9d7cb7b1ff1fdb0cac800ca0be4cf2290fe613b3d069dfe0d"

--- a/extensions/autobump-github/test_packages/simple_package/definition.yaml
+++ b/extensions/autobump-github/test_packages/simple_package/definition.yaml
@@ -1,0 +1,17 @@
+name: "golang"
+category: "build"
+version: 1.16.6+7
+base_url: https://golang.org/dl
+hidden: true # No need to make it installable for now
+labels:
+  autobump.revdeps: "false"
+  autobump.string_replace: '{ "prefix": "" }'
+  autobump.strategy: "custom"
+  autobump.prefix: "prefix"
+  autobump.hook: |
+    curl -s -L 'https://golang.org/VERSION?m=text' | sed 's/go//g'
+  autobump.version_hook: |
+    curl -s -L 'https://golang.org/VERSION?m=text' | sed 's/go//g'
+  package.version: "1.16.6"
+  autobump.checksum_hook: "curl -q -L https://storage.googleapis.com/golang/go{{.Values.labels.package.version}}.linux-amd64.tar.gz.sha256"
+  package.checksum: "be333ef18b3016e9d7cb7b1ff1fdb0cac800ca0be4cf2290fe613b3d069dfe0d"


### PR DESCRIPTION
The checksum hook for collections was not properly substituting values
as it was accessing the root values for the yaml file.

This patch makes it so it uses the YQ_ARGS available in other places in
order to access the proper subpackage when dealing with collections.

This pathc also changes the sed separator char to an @ as we currently
use / and that collides if there is an url as a value. It should be more
difficult to find an @ in the values..I hope


It also introduce a couple of simple tests for the extension and makes it run on CI