### PR TITLE
autobump-github: allow adding extra params to git commit

### DIFF
--- a/extensions/autobump-github/luet-autobump-github
+++ b/extensions/autobump-github/luet-autobump-github
@@ -13,6 +13,8 @@ fi
 
 # Options
 AUTO_GIT="${AUTO_GIT:-false}"
+GIT_SIGNOFF=${GIT_SIGNOFF:-false}
+GIT_COMMIT_ARGS=${GIT_COMMIT_ARGS:-}
 
 TOKEN="${TOKEN:-}" # e.g. -H "Authorization: token TOKEN"
 START_GIT_BRANCH="$(git rev-parse --abbrev-ref HEAD)"
@@ -20,6 +22,10 @@ HUB_ARGS="${HUB_ARGS:--b $START_GIT_BRANCH}"
 ROOT_DIR="${ROOT_DIR:-$PWD}"
 TREE_DIR="${TREE_DIR:-$ROOT_DIR/packages}"
 PKGAPI="${PKGAPI:-https://pkgapi.herokuapp.com}"
+
+if [[ "${AUTO_GIT}" == "true" ]] && [[ "${GIT_SIGNOFF}" == "true" ]]; then
+  GIT_COMMIT_ARGS="-s"
+fi
 
 funnyQuote() {
     messageQuote=(
@@ -109,7 +115,7 @@ reverse_bump() {
 
     if [ "${AUTO_GIT}" == "true" ]; then
         git add $path/
-        git commit -m "reverse dep: bump $i for $PACKAGE_CATEGORY/$PACKAGE_NAME"
+        git commit $GIT_COMMIT_ARGS -m "reverse dep: bump $i for $PACKAGE_CATEGORY/$PACKAGE_NAME"
         git push -f -v origin $BRANCH_NAME
 
         # Branch is ready now to open PR
@@ -344,7 +350,7 @@ for i in $(echo "$PKG_LIST" | jq -rc '.packages[]'); do
 
         if [ "${AUTO_GIT}" == "true" ]; then
             git add $PACKAGE_PATH/
-            git commit -m "Bump $PACKAGE_CATEGORY/$PACKAGE_NAME to $LATEST_TAG"
+            git commit $GIT_COMMIT_ARGS -m "Bump $PACKAGE_CATEGORY/$PACKAGE_NAME to $LATEST_TAG"
             git push -f -v origin $BRANCH_NAME
 
             # Branch is ready now to open PR


### PR DESCRIPTION
Allows adding extra params to git commit by adding those via env var.

Also provides functionality to make the commits signed off directly via
the same method but with a different env var for occasions in which the
commits need to by signed (i.e. DCO)

Signed-off-by: Itxaka <igarcia@suse.com>