### PR TITLE
Add github_tag strategy

### DIFF
--- a/extensions/autobump-github/luet-autobump-github
+++ b/extensions/autobump-github/luet-autobump-github
@@ -9,6 +9,7 @@ FAIL_ON_ERROR="${FAIL_ON_ERROR:-false}"
 
 if [[ $FAIL_ON_ERROR == "true" ]]; then
   set -e
+  set -o pipefail
 fi
 
 # Options
@@ -137,7 +138,7 @@ template_string() {
             continue
         fi
 
-        if [[ "$subkey" == "null" ]]; then 
+        if [[ "$subkey" == "null" ]]; then
             v=$(yq r $def "${YQ_ARGS}$key")
             string=$(echo "$string" | sed "s@{{.Values.$key}}@$v@g")
         else
@@ -332,6 +333,10 @@ for i in $(echo "$PKG_LIST" | jq -rc '.packages[]'); do
             GIT_BRANCH="${GIT_BRANCH:-master}"
             SHA=$(curl -H "Authorization: token $TOKEN" https://api.github.com/repos/$GITHUB_OWNER/$GITHUB_REPO/git/refs/heads/$GIT_BRANCH -s | jq -r '.object.sha')
             yq w -i $DEFINITION_FILE "${YQ_ARGS}labels.\"git.hash\"" "$SHA" --style double
+        fi
+
+        if [[ "$AUTOBUMP_STRATEGY" == "github_tag" ]]; then
+          yq w -i $DEFINITION_FILE "${YQ_ARGS}labels.\"github.tag\"" "$ORIGINAL_NEW_TAG" --style double
         fi
 
         if [ -n "$CHECKSUM_HOOK" ]; then

--- a/extensions/autobump-github/test_packages/github_package/definition.yaml
+++ b/extensions/autobump-github/test_packages/github_package/definition.yaml
@@ -1,0 +1,8 @@
+name: "extensions"
+category: "build"
+version: 0.11.1
+labels:
+  github.repo: "extensions"
+  github.owner: "luet-lab"
+  github.tag: "0.11.1 "
+  autobump.strategy: "github_tag"


### PR DESCRIPTION
Currently if using the "non-named" github strategy, autobum would use
the github{owner,repo} to check the new version but the original package
version would not be stored anywhere, thus tyieng the package version
with the underlying artifacts.

This intriduces the github_tag strategy which will store the original
remote source version into labels.github.tag for further use by packages

It also adds a test package for it and sets pipefail to exit so we can
properly fail on testing when dealing with pipes.

All current uses of the autobumper should not be affected by this change

Signed-off-by: Itxaka <igarcia@suse.com>