### PR TITLE
Add release tag and sed script to autobump extension

### DIFF
--- a/extensions/autobump-github/Makefile
+++ b/extensions/autobump-github/Makefile
@@ -12,4 +12,5 @@ install: build
 
 test:
 	TREE_DIR=test_packages FAIL_ON_ERROR=true ./luet-autobump-github
+	BASE_DIRECTORY="test_packages" ./validate_yaml_files.sh
 	git checkout test_packages

--- a/extensions/autobump-github/luet-autobump-github
+++ b/extensions/autobump-github/luet-autobump-github
@@ -309,7 +309,7 @@ for i in $(echo "$PKG_LIST" | jq -rc '.packages[]'); do
 
     [[ "$LATEST_TAG" == "null" ]] && LATEST_TAG=
     # versions are mismatching. Bump the version
-    if [ -n "$LATEST_TAG" ] && [ $LATEST_TAG != "$STRIPPED_PACKAGE_VERSION" ] ; then
+    if [ -n "$LATEST_TAG" ] && [ "$LATEST_TAG" != "$STRIPPED_PACKAGE_VERSION" ] ; then
         echo "Bumping $PACKAGE_CATEGORY/$PACKAGE_NAME to $LATEST_TAG"
 
         BRANCH_NAME="bump_${PACKAGE_NAME}_${PACKAGE_CATEGORY}"

--- a/extensions/autobump-github/luet-autobump-github
+++ b/extensions/autobump-github/luet-autobump-github
@@ -45,19 +45,19 @@ YQ_RELEASE="${YQ_RELEASE:-3.3.4}"
 HUB_RELEASE="${HUB_RELEASE:-2.14.2}"
 
 hash jq 2>/dev/null || {
-    mkdir $ROOT_DIR/.bin/;
+    mkdir -p $ROOT_DIR/.bin/;
     wget https://github.com/stedolan/jq/releases/download/jq-${JQ_RELEASE}/jq-linux64 -O $ROOT_DIR/.bin/jq
     chmod +x $ROOT_DIR/.bin/jq
 }
 
 hash yq 2>/dev/null || {
-    mkdir $ROOT_DIR/.bin/;
+    mkdir -p $ROOT_DIR/.bin/;
     wget https://github.com/mikefarah/yq/releases/download/${YQ_RELEASE}/yq_linux_amd64 -O $ROOT_DIR/.bin/yq
     chmod +x $ROOT_DIR/.bin/yq
 }
 
 hash hub 2>/dev/null || {
-    mkdir $ROOT_DIR/.bin/;
+    mkdir -p $ROOT_DIR/.bin/;
     wget https://github.com/github/hub/releases/download/v${HUB_RELEASE}/hub-linux-amd64-${HUB_RELEASE}.tgz -O $ROOT_DIR/.bin/hub
     chmod +x $ROOT_DIR/.bin/hub
 }

--- a/extensions/autobump-github/luet-autobump-github
+++ b/extensions/autobump-github/luet-autobump-github
@@ -188,6 +188,7 @@ for i in $(echo "$PKG_LIST" | jq -rc '.packages[]'); do
     # Best effort: get original package name from labels
     GITHUB_REPO=$(yq r $DEFINITION_FILE "${YQ_ARGS}labels.\"github.repo\"")
     GITHUB_OWNER=$(yq r $DEFINITION_FILE "${YQ_ARGS}labels.\"github.owner\"")
+    GITHUB_TAG=$(yq r $DEFINITION_FILE "${YQ_ARGS}labels.\"github.tag\"")
 
     # Strategy can be: release, tags or "refs"
     # Refs parses thru git tags
@@ -202,6 +203,9 @@ for i in $(echo "$PKG_LIST" | jq -rc '.packages[]'); do
 
     # A json map of replace rules
     STRING_REPLACE=$(yq r $DEFINITION_FILE "${YQ_ARGS}labels.\"autobump.string_replace\"")
+
+    # A sed script to run after the version has been retrieved
+    SED_REPLACE=$(yq r $DEFINITION_FILE "${YQ_ARGS}labels.\"autobump.sed_script\"")
 
 
     # A json list of strings contained in the releases to skip (e.g. betas)
@@ -280,12 +284,22 @@ for i in $(echo "$PKG_LIST" | jq -rc '.packages[]'); do
         fi
     elif [ "${AUTOBUMP_STRATEGY}" == "sabayon" ]; then
         LATEST_TAG=$(latest_sabayon $ORIGINAL_PACKAGE_NAME $ORIGINAL_PACKAGE_CATEGORY)
+    elif [[ "$AUTOBUMP_STRATEGY" == "release_tag" ]] && [ -n "${GITHUB_OWNER}" ] && [ -n "${GITHUB_REPO}" ] && [ -n "${GITHUB_TAG}" ]; then
+        if [ -n "$TOKEN" ]; then
+            LATEST_TAG=$(curl -H "Authorization: token $TOKEN" https://api.github.com/repos/$GITHUB_OWNER/$GITHUB_REPO/releases/tags/$GITHUB_TAG -s | jq .tag_name -r)
+        else
+            LATEST_TAG=$(curl https://api.github.com/repos/$GITHUB_OWNER/$GITHUB_REPO/releases/tags/$GITHUB_TAG -s | jq .tag_name -r )
+        fi
     elif [ -n "${GITHUB_OWNER}" ] && [ -n "${GITHUB_REPO}" ]; then
         if [ -n "$TOKEN" ]; then
             LATEST_TAG=$(curl -H "Authorization: token $TOKEN" https://api.github.com/repos/$GITHUB_OWNER/$GITHUB_REPO/tags -s | jq -r '.[].name | select(. | test("'$VERSION_CONTAINS'"))' -r | head -1 )
         else
             LATEST_TAG=$(curl https://api.github.com/repos/$GITHUB_OWNER/$GITHUB_REPO/tags -s | jq -r '.[].name | select(. | test("'$VERSION_CONTAINS'"))' -r | head -1 )
         fi
+    fi
+
+    if [ -n "$SED_REPLACE" ]; then
+        LATEST_TAG=$(echo "$LATEST_TAG" | sed -r "$SED_REPLACE")
     fi
 
     ORIGINAL_NEW_TAG=${LATEST_TAG}

--- a/extensions/autobump-github/test_packages/collection_package/collection.yaml
+++ b/extensions/autobump-github/test_packages/collection_package/collection.yaml
@@ -10,9 +10,9 @@ packages:
       autobump.strategy: "custom"
       autobump.prefix: "prefix"
       autobump.hook: |
-        curl -s -L 'https://golang.org/VERSION?m=text' | sed 's/go//g'
+        curl -s -L 'https://golang.org/VERSION?m=text' | sed 's/go//g' | sed -n '1p'
       autobump.version_hook: |
-        curl -s -L 'https://golang.org/VERSION?m=text' | sed 's/go//g'
+        curl -s -L 'https://golang.org/VERSION?m=text' | sed 's/go//g' | sed -n '1p'
       package.version: "1.16.6"
       autobump.checksum_hook: "curl -q -L https://storage.googleapis.com/golang/go{{.Values.labels.package.version}}.linux-amd64.tar.gz.sha256"
       package.checksum: "be333ef18b3016e9d7cb7b1ff1fdb0cac800ca0be4cf2290fe613b3d069dfe0d"
@@ -27,9 +27,9 @@ packages:
       autobump.strategy: "custom"
       autobump.prefix: "prefix"
       autobump.hook: |
-        curl -s -L 'https://golang.org/VERSION?m=text' | sed 's/go//g'
+        curl -s -L 'https://golang.org/VERSION?m=text' | sed 's/go//g' | sed -n '1p'
       autobump.version_hook: |
-        curl -s -L 'https://golang.org/VERSION?m=text' | sed 's/go//g'
+        curl -s -L 'https://golang.org/VERSION?m=text' | sed 's/go//g' | sed -n '1p'
       package.version: "1.16.6"
       autobump.checksum_hook: "curl -q -L https://storage.googleapis.com/golang/go{{.Values.labels.package.version}}.linux-amd64.tar.gz.sha256"
       package.checksum: "be333ef18b3016e9d7cb7b1ff1fdb0cac800ca0be4cf2290fe613b3d069dfe0d"

--- a/extensions/autobump-github/test_packages/collection_package/collection.yaml.golden
+++ b/extensions/autobump-github/test_packages/collection_package/collection.yaml.golden
@@ -1,7 +1,7 @@
 packages:
   - name: "golang1"
     category: "build"
-    version: 1.16.6+7
+    version: "1.21.3"
     base_url: https://golang.org/dl
     hidden: true # No need to make it installable for now
     labels:
@@ -13,12 +13,12 @@ packages:
         echo "1.21.3"
       autobump.version_hook: |
         echo "1.21.3"
-      package.version: "1.16.6"
+      package.version: "1.21.3"
       autobump.checksum_hook: "curl -q -L https://storage.googleapis.com/golang/go{{.Values.labels.package.version}}.linux-amd64.tar.gz.sha256"
-      package.checksum: "be333ef18b3016e9d7cb7b1ff1fdb0cac800ca0be4cf2290fe613b3d069dfe0d"
+      package.checksum: "1241381b2843fae5a9707eec1f8fb2ef94d827990582c7c7c32f5bdfbfd420c8"
   - name: "golang2"
     category: "build"
-    version: 1.16.6+7
+    version: "1.21.3"
     base_url: https://golang.org/dl
     hidden: true # No need to make it installable for now
     labels:
@@ -30,6 +30,6 @@ packages:
         echo "1.21.3"
       autobump.version_hook: |
         echo "1.21.3"
-      package.version: "1.16.6"
+      package.version: "1.21.3"
       autobump.checksum_hook: "curl -q -L https://storage.googleapis.com/golang/go{{.Values.labels.package.version}}.linux-amd64.tar.gz.sha256"
-      package.checksum: "be333ef18b3016e9d7cb7b1ff1fdb0cac800ca0be4cf2290fe613b3d069dfe0d"
+      package.checksum: "1241381b2843fae5a9707eec1f8fb2ef94d827990582c7c7c32f5bdfbfd420c8"

--- a/extensions/autobump-github/test_packages/complex_semver_package/collection.yaml
+++ b/extensions/autobump-github/test_packages/complex_semver_package/collection.yaml
@@ -1,0 +1,41 @@
+packages:
+  - name: k3s-openrc
+    category: k8s
+    version: "1.25.2"
+    k3s_version: "2"
+    labels:
+      github.owner: "k3s-io"
+      github.repo: "k3s"
+      github.tag: "v1.28.2+k3s1"
+      autobump.strategy: "release_tag"
+      autobump.sed_script: 's/\+k3s1//g'
+    uri:
+      - https://github.com/k3s-io/k3s
+    license: "APL-2"
+    description: " Lightweight Kubernetes "
+  - name: k3s-openrc
+    category: k8s
+    version: "1.26.3"
+    k3s_version: "2"
+    labels:
+      github.owner: "k3s-io"
+      github.repo: "k3s"
+      autobump.strategy: "release"
+      autobump.sed_replace: "s/+k3s1//g"
+    uri:
+      - https://github.com/k3s-io/k3s
+    license: "APL-2"
+    description: " Lightweight Kubernetes "
+  - name: k3s-openrc
+    category: k8s
+    version: "1.27.3"
+    k3s_version: "2"
+    labels:
+      github.owner: "k3s-io"
+      github.repo: "k3s"
+      autobump.strategy: "release"
+      autobump.sed_replace: "s/+k3s1//g"
+    uri:
+      - https://github.com/k3s-io/k3s
+    license: "APL-2"
+    description: " Lightweight Kubernetes "

--- a/extensions/autobump-github/test_packages/complex_semver_package/collection.yaml.golden
+++ b/extensions/autobump-github/test_packages/complex_semver_package/collection.yaml.golden
@@ -1,0 +1,41 @@
+packages:
+  - name: k3s-openrc
+    category: k8s
+    version: "1.28.2"
+    k3s_version: "2"
+    labels:
+      github.owner: "k3s-io"
+      github.repo: "k3s"
+      github.tag: "v1.28.2+k3s1"
+      autobump.strategy: "release_tag"
+      autobump.sed_script: 's/\+k3s1//g'
+    uri:
+      - https://github.com/k3s-io/k3s
+    license: "APL-2"
+    description: " Lightweight Kubernetes "
+  - name: k3s-openrc
+    category: k8s
+    version: "1.26.3"
+    k3s_version: "2"
+    labels:
+      github.owner: "k3s-io"
+      github.repo: "k3s"
+      autobump.strategy: "release"
+      autobump.sed_replace: "s/+k3s1//g"
+    uri:
+      - https://github.com/k3s-io/k3s
+    license: "APL-2"
+    description: " Lightweight Kubernetes "
+  - name: k3s-openrc
+    category: k8s
+    version: "1.27.3"
+    k3s_version: "2"
+    labels:
+      github.owner: "k3s-io"
+      github.repo: "k3s"
+      autobump.strategy: "release"
+      autobump.sed_replace: "s/+k3s1//g"
+    uri:
+      - https://github.com/k3s-io/k3s
+    license: "APL-2"
+    description: " Lightweight Kubernetes "

--- a/extensions/autobump-github/test_packages/github_package/definition.yaml.golden
+++ b/extensions/autobump-github/test_packages/github_package/definition.yaml.golden
@@ -1,0 +1,8 @@
+name: "extensions"
+category: "build"
+version: "0.11.8"
+labels:
+  github.repo: "extensions"
+  github.owner: "luet-lab"
+  github.tag: "v0.11.8"
+  autobump.strategy: "github_tag"

--- a/extensions/autobump-github/test_packages/simple_package/definition.yaml
+++ b/extensions/autobump-github/test_packages/simple_package/definition.yaml
@@ -9,9 +9,9 @@ labels:
   autobump.strategy: "custom"
   autobump.prefix: "prefix"
   autobump.hook: |
-    curl -s -L 'https://golang.org/VERSION?m=text' | sed 's/go//g'
+    curl -s -L 'https://golang.org/VERSION?m=text' | sed 's/go//g' | sed -n '1p'
   autobump.version_hook: |
-    curl -s -L 'https://golang.org/VERSION?m=text' | sed 's/go//g'
+    curl -s -L 'https://golang.org/VERSION?m=text' | sed 's/go//g' | sed -n '1p'
   package.version: "1.16.6"
   autobump.checksum_hook: "curl -q -L https://storage.googleapis.com/golang/go{{.Values.labels.package.version}}.linux-amd64.tar.gz.sha256"
   package.checksum: "be333ef18b3016e9d7cb7b1ff1fdb0cac800ca0be4cf2290fe613b3d069dfe0d"

--- a/extensions/autobump-github/test_packages/simple_package/definition.yaml.golden
+++ b/extensions/autobump-github/test_packages/simple_package/definition.yaml.golden
@@ -1,6 +1,6 @@
 name: "golang"
 category: "build"
-version: 1.16.6+7
+version: "1.21.3"
 base_url: https://golang.org/dl
 hidden: true # No need to make it installable for now
 labels:
@@ -12,6 +12,6 @@ labels:
     echo "1.21.3"
   autobump.version_hook: |
     echo "1.21.3"
-  package.version: "1.16.6"
+  package.version: "1.21.3"
   autobump.checksum_hook: "curl -q -L https://storage.googleapis.com/golang/go{{.Values.labels.package.version}}.linux-amd64.tar.gz.sha256"
-  package.checksum: "be333ef18b3016e9d7cb7b1ff1fdb0cac800ca0be4cf2290fe613b3d069dfe0d"
+  package.checksum: "1241381b2843fae5a9707eec1f8fb2ef94d827990582c7c7c32f5bdfbfd420c8"

--- a/extensions/autobump-github/validate_yaml_files.sh
+++ b/extensions/autobump-github/validate_yaml_files.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+echo "Validating YAML files..."
+for package_directory in "$BASE_DIRECTORY"/*; do
+  echo $package_directory
+    # Check if it's a directory
+    if [ -d "$package_directory" ]; then
+          # Print the package name (directory name) and the content of collection.yaml
+          if [ -f "$package_directory/collection.yaml" ]; then
+              diff "$package_directory"/collection.yaml "$package_directory"/collection.yaml.golden
+
+              if [ $? -ne 0 ]; then
+                  echo "Changes don't match the golden file for package $package_directory. Exiting..."
+                  exit 1
+              fi
+          fi
+
+          if [ -f "$package_directory/definition.yaml" ]; then
+              diff "$package_directory"/definition.yaml "$package_directory"/definition.yaml.golden
+
+              if [ $? -ne 0 ]; then
+                  echo "Changes don't match the golden file for package $package_directory. Exiting..."
+                  exit 1
+              fi
+          fi
+    fi
+done


### PR DESCRIPTION
Fixes https://github.com/kairos-io/kairos/issues/1934

- adds tests for the autobump functionality using golden files
- extend autobump to use a specific release tag
- extend autobump to use a specific sed script instead of multiple keys and replace, since this breaks with fancy scripts like `\+k3s` :p 